### PR TITLE
chore: added config to group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Weekly PRs for security updates, grouped into one PR
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    target-branch: "dev"
+
+  # Monthly bundled PR for all routine version updates
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    target-branch: "dev"


### PR DESCRIPTION
#### Issue: # <!-- put the issue number here -->

#### Summary

<!-- Briefly describe your changes here -->
<!-- Ex:
* Fixed the issue where team schedules are shifted backward.
* Polished dashboard loading states.
* Refactored API client tests.
-->

- Dependabot opens too many PRs
- https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file

<!-- Sometimes it helps to summarize your commits instead. If that's the case, use the command below. -->
<!-- git log origin/dev..HEAD --no-merges --pretty=format:"* %h - %an: %s (%ar)" -->

#### Checklist

- [ ] I linked to an issue with 'Issue: #'
- [ ] I tested this manually
- [ ] I added unit tests
- [ ] I made sure all tests pass locally
